### PR TITLE
Add Android C++ support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@
 
 # CMake build directory
 build
+
+# Gradle / Android build outputs
+.gradle

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,11 @@ if (NOT Slint_FOUND)
   FetchContent_MakeAvailable(Slint)
 endif (NOT Slint_FOUND)
 
-add_executable(my_application src/main.cpp)
+if(ANDROID)
+    add_library(my_application SHARED src/main.cpp)
+else()
+    add_executable(my_application src/main.cpp)
+endif()
 target_link_libraries(my_application PRIVATE Slint::Slint)
 slint_target_sources(my_application ui/app-window.slint)
 # On Windows, copy the Slint DLL next to the application binary so that it's found.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,35 @@ Alternatively, this template will automatically download the Slint sources and c
 
 We recommend using an IDE for development, along with our [LSP-based IDE integration for `.slint` files](https://github.com/slint-ui/slint/blob/master/tools/lsp/README.md). You can also load this project directly in [Visual Studio Code](https://code.visualstudio.com) and install our [Slint extension](https://marketplace.visualstudio.com/items?itemName=Slint.slint).
 
+## Building for Android
+
+The `android/` directory contains a Gradle wrapper around this CMake project that produces an Android APK.
+
+Prerequisites:
+  * [Android Studio](https://developer.android.com/studio) with the Android SDK, NDK, and CMake (in *SDK Tools*).
+  * `ANDROID_HOME` and `ANDROID_NDK_ROOT` set in your environment.
+  * Rust (see above) plus the Android target:
+    ```
+    rustup target add aarch64-linux-android
+    ```
+
+To build and install on a connected device or running emulator:
+
+```
+cd android
+./gradlew installDebug
+```
+
+The first build is slow because Slint and the Skia renderer are compiled from source. View application logs with:
+
+```
+adb logcat -s slint
+```
+
+To target additional ABIs, add them to `abiFilters` in `android/build.gradle.kts` and install the matching Rust targets (`armv7-linux-androideabi`, `x86_64-linux-android`, `i686-linux-android`).
+
+See the [Slint Android guide](https://slint.dev/docs/cpp/platforms/mobile/android) for more details.
+
 ## Next Steps
 
 We hope that this template helps you get started and you enjoy exploring making user interfaces with Slint. To learn more

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,35 @@
+plugins {
+    id("com.android.application") version "8.7.0"
+}
+
+android {
+    namespace = "com.example.myapplication"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "com.example.myapplication"
+        // API 26 is the minimum supported by the Slint Android backend.
+        minSdk = 26
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
+
+        ndk {
+            // Add other ABIs as needed: "armeabi-v7a", "x86_64", "x86"
+            abiFilters += "arm64-v8a"
+        }
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path = file("../CMakeLists.txt")
+            version = "3.22.1"
+        }
+    }
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "MyApplication"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:label="My Application"
+        android:hasCode="false">
+        <activity
+            android:name="android.app.NativeActivity"
+            android:exported="true"
+            android:configChanges="orientation|screenSize|keyboardHidden">
+            <meta-data
+                android:name="android.app.lib_name"
+                android:value="my_application" />
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,10 @@
 #include "app-window.h"
 
+#ifdef __ANDROID__
+extern "C" void slint_main()
+#else
 int main(int argc, char **argv)
+#endif
 {
     auto ui = AppWindow::create();
 
@@ -9,5 +13,4 @@ int main(int argc, char **argv)
     });
 
     ui->run();
-    return 0;
 }


### PR DESCRIPTION
Build a shared library on Android (NDK auto-detected by Slint's CMake) and provide an extern "C" slint_main() entry point. Add a Gradle wrapper under android/ so users can run ./gradlew installDebug.